### PR TITLE
Default to light theme in settings

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -45,9 +45,9 @@ namespace WaxIPTV.ViewModels
 
         // ----- Friendly Theme fields -----
         [ObservableProperty]
-        private string bgHex = "#0B0B0F";
+        private string bgHex = "#FFFFFF";
         [ObservableProperty]
-        private string textHex = "#FFFFFF";
+        private string textHex = "#0B0B0F";
         [ObservableProperty]
         private string accentHex = "#5B8CFF";
         [ObservableProperty]


### PR DESCRIPTION
## Summary
- Default SettingsViewModel theme colors to a light palette

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" because the SDK is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_689a584ebf84832e9a12ecb42b35bb4f