### PR TITLE
Handle gzipped EPG downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ handling.
    - `player`: `"mpv"` or `"vlc"`.
    - `mpvPath`/`vlcPath`: absolute paths to the players’ executables.
    - `playlistUrl`: a local path to your M3U playlist.
-   - `xmltvUrl`: a local path to your XMLTV EPG.
+   - `xmltvUrl`: a local path or HTTP(S) URL to your XMLTV EPG (plain or gzipped).
    - `epgRefreshHours`: how often, in hours, to reload the EPG.
 4. Place your playlist (`.m3u` or `.m3u8`) and EPG (`.xml`, optionally compressed) in locations accessible by the app and update the paths in `settings.json`.  When you launch the app again, the channel list will be populated from the playlist and the Now/Next panel will show programme information from the EPG.
 5. Click **Play**, **Pause** and **Stop** to control the chosen external player.  If no player is available (paths are blank and detection fails), the playback buttons will be disabled.


### PR DESCRIPTION
## Summary
- support gzipped EPG sources by downloading bytes and decompressing before parsing
- cache fetched EPG XML locally and reuse cache for guide and now/next views
- document that xmltvUrl may be a remote or gzipped feed

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_b_689a5f30bad8832ead7e8b8b7af7db8e