### PR TITLE
Fix ISO 8601 XMLTV timestamp parsing

### DIFF
--- a/Services/Xmltv.cs
+++ b/Services/Xmltv.cs
@@ -118,6 +118,20 @@ namespace WaxIPTV.Services
 
             raw = raw.Trim();
 
+            // Many XMLTV feeds now provide ISO 8601 timestamps such as
+            // "2024-05-03T20:00:00Z" or "2024-05-03T20:00:00+02:00".  These
+            // formats are not handled by the original custom parsing logic
+            // below, so attempt a standard DateTimeOffset parse first.  If
+            // successful we normalise to UTC and return immediately.
+            if (DateTimeOffset.TryParse(
+                    raw,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out var isoDto))
+            {
+                return isoDto;
+            }
+
             // Separate date/time part and timezone part
             string datePart = raw;
             string tzPart = string.Empty;


### PR DESCRIPTION
## Summary
- support ISO 8601 formatted timestamps when parsing XMLTV EPG data

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_b_689a62a9b230832e89f37b72bf38f83a