### PR TITLE
Stream EPG parsing in batches and auto-map missing tvg-ids

### DIFF
--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -448,9 +448,9 @@ namespace WaxIPTV.Views
             {
                 try
                 {
-                    var (channelNames, programmes) = Xmltv.Parse(xml);
-                    var ordered = programmes.OrderBy(p => p.StartUtc).ToList();
-                    programmesDict = EpgMapper.MapProgrammes(ordered, _channels, channelNames);
+                    var channelNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    var programmesEnum = Xmltv.StreamProgrammes(xml, channelNames);
+                    programmesDict = EpgMapper.MapProgrammesInBatches(programmesEnum, _channels, channelNames, 200);
                     // Trim programmes beyond 7 days to limit memory usage
                     var cutoff = DateTimeOffset.UtcNow.AddDays(7);
                     foreach (var kv in programmesDict)


### PR DESCRIPTION
## Summary
- Stream XMLTV programmes so EPG can be processed in small batches
- Auto-match and cache `tvg-id` values when missing or invalid
- Load EPG using the new streaming API and omit unmatched channels

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_b_689a6f3a2c4c832ea5ba780b3c331700