### PR TITLE
Build EPG guide rows asynchronously

### DIFF
--- a/Views/GuideWindow.xaml.cs
+++ b/Views/GuideWindow.xaml.cs
@@ -56,7 +56,7 @@ namespace WaxIPTV.Views
             Loaded += OnLoaded;
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        private async void OnLoaded(object sender, RoutedEventArgs e)
         {
             // Populate group filter ComboBox
             var groups = _allChannels
@@ -71,11 +71,12 @@ namespace WaxIPTV.Views
             GroupFilter.SelectedIndex = 0;
             _selectedGroup = "All";
 
-            // Build initial guide rows
+            // Build initial guide rows in the background so the UI remains
+            // responsive even with large channel/EPG datasets.
             // Precompute all guide rows once; we'll filter these instead of
             // rebuilding programme slots on every search or group change.  The
             // time window is anchored at the moment of loading.
-            _allGuideRows = BuildGuideRows(_allChannels);
+            _allGuideRows = await Task.Run(() => BuildGuideRows(_allChannels));
 
             ApplyFilterAndBuildGuide();
 


### PR DESCRIPTION
## Summary
- Build initial EPG guide rows on a background thread so the UI remains responsive during loading

## Testing
- `dotnet build` *(fails: SDK "Microsoft.NET.Sdk.WindowsDesktop" not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a7410019c832eb564c3ef1a2f8c5b