### PR TITLE
Guard dialog result and handle duplicate EPG channel IDs

### DIFF
--- a/Services/EpgMapper.cs
+++ b/Services/EpgMapper.cs
@@ -110,9 +110,15 @@ namespace WaxIPTV.Services
                     tlist.Add(c);
                 }
             }
-            var channelIndex = channels
-                .Select((c, i) => new { c.Id, Index = i })
-                .ToDictionary(x => x.Id, x => x.Index, StringComparer.OrdinalIgnoreCase);
+            var channelIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < channels.Count; i++)
+            {
+                var c = channels[i];
+                if (!channelIndex.TryAdd(c.Id, i))
+                {
+                    AppLog.Logger.Warning("Duplicate channel ID {ChannelId} encountered; keeping first occurrence", c.Id);
+                }
+            }
 
             var result = new Dictionary<string, List<Programme>>();
 

--- a/Services/MpvController.cs
+++ b/Services/MpvController.cs
@@ -127,9 +127,20 @@ namespace WaxIPTV.Services
                 return;
             var json = System.Text.Json.JsonSerializer.Serialize(payload) + "\n";
             var bytes = System.Text.Encoding.UTF8.GetBytes(json);
-            await _pipe.WriteAsync(bytes, 0, bytes.Length, ct);
-            await _pipe.FlushAsync(ct);
-            AppLog.Logger.Debug("mpv cmd {Json}", AppLog.Safe(json.Trim()));
+            try
+            {
+                await _pipe.WriteAsync(bytes, 0, bytes.Length, ct);
+                await _pipe.FlushAsync(ct);
+                AppLog.Logger.Debug("mpv cmd {Json}", AppLog.Safe(json.Trim()));
+            }
+            catch (IOException ex)
+            {
+                AppLog.Logger.Warning(ex, "Failed to send command to mpv");
+            }
+            catch (ObjectDisposedException ex)
+            {
+                AppLog.Logger.Warning(ex, "Failed to send command to mpv");
+            }
         }
 
         /// <summary>

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -346,14 +346,34 @@ namespace WaxIPTV.ViewModels
                 await DownloadEpg();
             }
 
-            window.DialogResult = true;
+            try
+            {
+                if (window.IsVisible)
+                {
+                    window.DialogResult = true;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Window was not shown as a dialog; ignore failure to set DialogResult.
+            }
             window.Close();
         }
 
         [RelayCommand]
         private void Cancel(Window window)
         {
-            window.DialogResult = false;
+            try
+            {
+                if (window.IsVisible)
+                {
+                    window.DialogResult = false;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Window was not shown as a dialog; ignore failure to set DialogResult.
+            }
             window.Close();
         }
 


### PR DESCRIPTION
## Summary
- avoid unhandled InvalidOperationException by guarding DialogResult assignments in `SettingsViewModel`
- prevent duplicate-key crashes in EPG mapping by tracking channel IDs with `TryAdd`
- handle broken mpv IPC pipe by catching IO/ObjectDisposed exceptions when sending commands

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_b_68a397641758832e9d82164f13242894