### PR TITLE
Run EPG parsing asynchronously to improve responsiveness

### DIFF
--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -560,9 +560,11 @@ namespace WaxIPTV.Views
             // 4) Parse the XML if available
             if (!string.IsNullOrEmpty(xml))
             {
-                try
+                await System.Threading.Tasks.Task.Run(() =>
                 {
-                    AppLog.Logger.Information("Parsing EPG XML");
+                    try
+                    {
+                        AppLog.Logger.Information("Parsing EPG XML");
                     var channelNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                     int totalProgrammes = 0;
                     int shiftMinutes = 0;
@@ -739,6 +741,7 @@ namespace WaxIPTV.Views
                     programmesDict.Clear();
                     AppLog.Logger.Error(ex, "Failed to parse or map EPG");
                 }
+                });
             }
 
             _programmes = programmesDict;


### PR DESCRIPTION
## Summary
- parse and map EPG data on a background thread to keep the UI responsive during large XML loads

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_b_68a39d1eca18832ebffe7e95f3d4f8af