### PR TITLE
Show progressive EPG loading and skip invalid programmes

### DIFF
--- a/Services/EpgMapper.cs
+++ b/Services/EpgMapper.cs
@@ -32,7 +32,7 @@ namespace WaxIPTV.Services
             Dictionary<string, string>? overrides = null)
         {
             AppLog.Logger.Information("Mapping {ProgCount} programmes", programmes.Count);
-            return MapProgrammesInBatches(programmes, channels, channelNames, int.MaxValue, overrides);
+            return MapProgrammesInBatches(programmes, channels, channelNames, int.MaxValue, overrides, null);
         }
 
         /// <summary>
@@ -55,7 +55,8 @@ namespace WaxIPTV.Services
             List<Channel> channels,
             Dictionary<string, string> channelNames,
             int batchSize,
-            Dictionary<string, string>? overrides = null)
+            Dictionary<string, string>? overrides = null,
+            IProgress<int>? progress = null)
         {
             using var scope = AppLog.BeginScope("EpgMap");
             overrides ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -121,6 +122,7 @@ namespace WaxIPTV.Services
             }
 
             var result = new Dictionary<string, List<Programme>>();
+            int processed = 0;
 
             foreach (var chunk in programmes.Chunk(batchSize))
             {
@@ -228,6 +230,9 @@ namespace WaxIPTV.Services
                         list.Add(prog);
                     }
                 }
+
+                processed += chunk.Length;
+                progress?.Report(processed);
             }
 
             foreach (var list in result.Values)

--- a/Services/Xmltv.cs
+++ b/Services/Xmltv.cs
@@ -96,14 +96,15 @@ namespace WaxIPTV.Services
                             desc = sub.ReadElementContentAsString();
                         }
                     }
-                    // Only include the programme if it has a channel and valid times
+                    // Only include the programme if it has a channel, title and valid times
                     if (!string.IsNullOrWhiteSpace(channelId) &&
+                        !string.IsNullOrWhiteSpace(title) &&
                         start != DateTimeOffset.MinValue &&
                         stop != DateTimeOffset.MinValue &&
                         stop > start)
                     {
                         // Use empty strings for missing fields to avoid nulls; description remains nullable
-                        programmes.Add(new Programme(channelId, start, stop, title ?? string.Empty, desc));
+                        programmes.Add(new Programme(channelId, start, stop, title!.Trim(), desc));
                     }
                 }
             }
@@ -184,11 +185,12 @@ namespace WaxIPTV.Services
                             desc = sub.ReadElementContentAsString();
                     }
                     if (!string.IsNullOrWhiteSpace(channelId) &&
+                        !string.IsNullOrWhiteSpace(title) &&
                         start != DateTimeOffset.MinValue &&
                         stop != DateTimeOffset.MinValue &&
                         stop > start)
                     {
-                        yield return new Programme(channelId, start, stop, title ?? string.Empty, desc);
+                        yield return new Programme(channelId, start, stop, title!.Trim(), desc);
                     }
                 }
             }

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -611,7 +611,22 @@ namespace WaxIPTV.Views
 
                     // Map the programmes to channels using the batched mapper. The stream
                     // enumerates lazily, keeping memory usage low when handling large EPGs.
-                    programmesDict = EpgMapper.MapProgrammesInBatches(programmeStream, _channels, channelNames, 200, overrides);
+                    var progress = new Progress<int>(count =>
+                    {
+                        try
+                        {
+                            Dispatcher.Invoke(() =>
+                            {
+                                if (MainEpgLoadingLabel != null)
+                                    MainEpgLoadingLabel.Text = $"Loading EPG... ({count} programmes)";
+                            });
+                        }
+                        catch
+                        {
+                            // ignore UI update errors
+                        }
+                    });
+                    programmesDict = EpgMapper.MapProgrammesInBatches(programmeStream, _channels, channelNames, 200, overrides, progress);
                     AppLog.Logger.Information("Mapping {ProgCount} programmes", totalProgrammes);
                     // Trim programmes beyond 7 days to limit memory usage
                     var cutoff = DateTimeOffset.UtcNow.AddDays(7);


### PR DESCRIPTION
## Summary
- update EPG mapper with progress reporting to display programme counts as the guide loads
- filter XMLTV parsing to ignore programmes without titles for more accurate EPG data
- update main window to surface programme load counts during EPG mapping

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3ab7d3784832ebcec0e41c8cefcda