### PR TITLE
Show EPG data during incremental load

### DIFF
--- a/Views/GuideWindow.xaml.cs
+++ b/Views/GuideWindow.xaml.cs
@@ -236,7 +236,12 @@ namespace WaxIPTV.Views
                     ChannelIcon = LoadIcon(ch.Logo),
                     ProgrammeSlots = new List<ProgrammeSlot>()
                 };
-                if (_programmes.TryGetValue(ch.Id, out var progs))
+                List<Programme>? progs;
+                lock (_programmes)
+                {
+                    _programmes.TryGetValue(ch.Id, out progs);
+                }
+                if (progs != null)
                 {
                     foreach (var prog in progs)
                     {
@@ -403,7 +408,12 @@ namespace WaxIPTV.Views
             var totalMinutes = _windowDuration.TotalMinutes;
             var pixelsPerMinute = _timelineWidth / totalMinutes;
             // Populate programme slots
-            if (_programmes.TryGetValue(ch.Id, out var progs))
+            List<Programme>? progs;
+            lock (_programmes)
+            {
+                _programmes.TryGetValue(ch.Id, out progs);
+            }
+            if (progs != null)
             {
                 foreach (var prog in progs)
                 {


### PR DESCRIPTION
## Summary
- Stream EPG programme mapping and expose progress callbacks
- Update main window's EPG loading to populate data incrementally and refresh Now/Next
- Guard programme lookups with locks for thread safety

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3adc90178832ea468eaec43abd1dc