### PR TITLE
Display EPG data during loading

### DIFF
--- a/Services/EpgMapper.cs
+++ b/Services/EpgMapper.cs
@@ -56,7 +56,8 @@ namespace WaxIPTV.Services
             Dictionary<string, string> channelNames,
             int batchSize,
             Dictionary<string, string>? overrides = null,
-            IProgress<int>? progress = null)
+            IProgress<int>? progress = null,
+            Dictionary<string, List<Programme>>? existing = null)
         {
             using var scope = AppLog.BeginScope("EpgMap");
             overrides ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -121,7 +122,7 @@ namespace WaxIPTV.Services
                 }
             }
 
-            var result = new Dictionary<string, List<Programme>>();
+            var result = existing ?? new Dictionary<string, List<Programme>>();
             int processed = 0;
 
             foreach (var chunk in programmes.Chunk(batchSize))

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -471,6 +471,7 @@ namespace WaxIPTV.Views
             }
 
             var programmesDict = new Dictionary<string, List<Programme>>();
+            _programmes = programmesDict;
             var cachePath = GetEpgCachePath();
             string? xml = null;
 
@@ -619,6 +620,8 @@ namespace WaxIPTV.Views
                             {
                                 if (MainEpgLoadingLabel != null)
                                     MainEpgLoadingLabel.Text = $"Loading EPG... ({count} programmes)";
+                                // Update now/next display as data becomes available
+                        UpdateNowNextForSelected();
                             });
                         }
                         catch
@@ -626,7 +629,7 @@ namespace WaxIPTV.Views
                             // ignore UI update errors
                         }
                     });
-                    programmesDict = EpgMapper.MapProgrammesInBatches(programmeStream, _channels, channelNames, 200, overrides, progress);
+                    programmesDict = EpgMapper.MapProgrammesInBatches(programmeStream, _channels, channelNames, 200, overrides, progress, programmesDict);
                     AppLog.Logger.Information("Mapping {ProgCount} programmes", totalProgrammes);
                     // Trim programmes beyond 7 days to limit memory usage
                     var cutoff = DateTimeOffset.UtcNow.AddDays(7);


### PR DESCRIPTION
## Summary
- Populate `_programmes` dictionary before mapping so channels show guide info as soon as it's parsed
- Update now/next display during EPG load for more responsive UI
- Allow `EpgMapper` to populate an existing dictionary for incremental updates

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop" on this Linux environment)*

------
https://chatgpt.com/codex/tasks/task_b_68a3b1ad4ab8832e9b171ce8bb1e93bf