### PR TITLE
Show complete channel EPG and add top menu search

### DIFF
--- a/Views/EpgNowNext.xaml
+++ b/Views/EpgNowNext.xaml
@@ -6,25 +6,24 @@
              mc:Ignorable="d"
              Height="Auto" Width="Auto">
     <!--
-        A simple view to display the currently airing programme (Now) and
-        the upcoming programme (Next) for a selected channel. This
-        UserControl relies on two dependency properties, `NowProgramme`
-        and `NextProgramme`, which can be bound from a viewmodel or
-        manually set in code-behind. Each programme is displayed with
-        its title and time range converted to local time.
+        Displays the full programme schedule for a channel.  Programmes are
+        listed in order with their local start/end times and descriptions.
+        The list is wrapped in a surface-coloured card using the design
+        tokens for consistent rounding and spacing.
     -->
-    <!-- Present now/next information inside a surface coloured card.  The
-         border uses the ThemeCornerRadius token to ensure rounding
-         matches the rest of the UI, and spacing tokens provide
-         consistent padding. -->
     <Border Background="{DynamicResource SurfaceBrush}"
             CornerRadius="{DynamicResource ThemeCornerRadius}"
             Padding="{DynamicResource SpacingM}">
-        <StackPanel>
-            <TextBlock Text="Now:" FontWeight="Bold" Foreground="{DynamicResource MutedTextBrush}"/>
-            <TextBlock x:Name="NowText" Text="No programme" Margin="0,0,0,8"/>
-            <TextBlock Text="Next:" FontWeight="Bold" Foreground="{DynamicResource MutedTextBrush}"/>
-            <TextBlock x:Name="NextText" Text="No programme"/>
-        </StackPanel>
+        <ListBox x:Name="ProgrammeList" BorderThickness="0">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Margin="0,0,0,8">
+                        <TextBlock Text="{Binding Title}" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding TimeRange}" Foreground="{DynamicResource MutedTextBrush}"/>
+                        <TextBlock Text="{Binding Description}" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
     </Border>
 </UserControl>

--- a/Views/EpgNowNext.xaml.cs
+++ b/Views/EpgNowNext.xaml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using WaxIPTV.Models;
@@ -17,36 +19,34 @@ namespace WaxIPTV.Views
         }
 
         /// <summary>
-        /// Updates the display of the now and next programmes. The
-        /// programmes should have their times specified in UTC; this
-        /// method converts them to the local time zone using
-        /// DateTimeOffset.ToLocalTime().
+        /// Updates the list of programmes for the selected channel.  The
+        /// programmes should be provided in UTC and are converted to the
+        /// local time zone before display.
         /// </summary>
-        /// <param name="now">The programme currently airing.</param>
-        /// <param name="next">The programme airing after the current one.</param>
-        public void UpdateProgrammes(Programme? now, Programme? next)
+        /// <param name="programmes">All programmes for the channel in start time order.</param>
+        public void UpdateProgrammes(List<Programme>? programmes)
         {
-            if (now != null)
+            if (programmes == null || programmes.Count == 0)
             {
-                var localStart = now.StartUtc.ToLocalTime().DateTime;
-                var localEnd = now.EndUtc.ToLocalTime().DateTime;
-                NowText.Text = $"{now.Title} ({FormatRange(localStart, localEnd)})";
-            }
-            else
-            {
-                NowText.Text = "No programme";
+                ProgrammeList.ItemsSource = new List<ProgrammeDisplay>
+                {
+                    new("No programme", string.Empty, string.Empty)
+                };
+                return;
             }
 
-            if (next != null)
+            var items = programmes.Select(p =>
             {
-                var localStart = next.StartUtc.ToLocalTime().DateTime;
-                var localEnd = next.EndUtc.ToLocalTime().DateTime;
-                NextText.Text = $"{next.Title} ({FormatRange(localStart, localEnd)})";
-            }
-            else
-            {
-                NextText.Text = "No programme";
-            }
+                var localStart = p.StartUtc.ToLocalTime().DateTime;
+                var localEnd = p.EndUtc.ToLocalTime().DateTime;
+                return new ProgrammeDisplay(
+                    p.Title,
+                    FormatRange(localStart, localEnd),
+                    p.Desc ?? string.Empty
+                );
+            }).ToList();
+
+            ProgrammeList.ItemsSource = items;
         }
 
         /// <summary>
@@ -59,5 +59,7 @@ namespace WaxIPTV.Views
             string endStr = end.ToString("t", CultureInfo.CurrentCulture);
             return $"{startStr} - {endStr}";
         }
+
+        private record ProgrammeDisplay(string Title, string TimeRange, string Description);
     }
 }

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -19,19 +19,35 @@
         the currently active external player.
     -->
     <DockPanel>
-        <!-- Top menu bar -->
-        <Menu DockPanel.Dock="Top">
-            <MenuItem Header="_File">
-                <MenuItem Header="Settings..." Click="SettingsMenu_Click" InputGestureText="Ctrl+,"/>
-                <MenuItem Header="EPG Guide" Click="GuideMenu_Click"/>
-                <MenuItem Header="Refresh (Playlist + EPG)" Click="RefreshMenu_Click"/>
-                <!-- Reloads only the EPG for the current playlist ignoring the refresh interval.  
-                     Useful for forcing a re-download and remap without reloading the playlist. -->
-                <MenuItem Header="Reload EPG (force)" Click="ReloadEpgForce_Click"/>
-                <Separator/>
-                <MenuItem Header="Exit" Click="ExitMenu_Click"/>
-            </MenuItem>
-        </Menu>
+        <!-- Top menu bar with search -->
+        <DockPanel DockPanel.Dock="Top">
+            <Menu DockPanel.Dock="Left">
+                <MenuItem Header="_File">
+                    <MenuItem Header="Settings..." Click="SettingsMenu_Click" InputGestureText="Ctrl+,"/>
+                    <MenuItem Header="EPG Guide" Click="GuideMenu_Click"/>
+                    <MenuItem Header="Refresh (Playlist + EPG)" Click="RefreshMenu_Click"/>
+                    <!-- Reloads only the EPG for the current playlist ignoring the refresh interval.
+                         Useful for forcing a re-download and remap without reloading the playlist. -->
+                    <MenuItem Header="Reload EPG (force)" Click="ReloadEpgForce_Click"/>
+                    <Separator/>
+                    <MenuItem Header="Exit" Click="ExitMenu_Click"/>
+                </MenuItem>
+            </Menu>
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Margin="8,0,0,0">
+                <Button Content="Clear"
+                        Click="ClearSearch_Click"
+                        Style="{DynamicResource AccentButton}"
+                        Margin="0,0,8,0"/>
+                <TextBox x:Name="SearchBox"
+                         Width="400"
+                         VerticalAlignment="Center"
+                         TextChanged="SearchBox_TextChanged"
+                         Background="{DynamicResource SurfaceBrush}"
+                         Foreground="{DynamicResource TextBrush}"
+                         BorderBrush="{DynamicResource DividerBrush}"
+                         BorderThickness="1"/>
+            </StackPanel>
+        </DockPanel>
 
         <!-- EPG loading indicator.  This panel shows a brief message and
              an indeterminate progress bar while the EPG data is being
@@ -68,10 +84,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <!-- Filter bar: provides a group selector and search box.  The
-                     search box occupies remaining space thanks to DockPanel.
-                     Controls use SurfaceBrush and DividerBrush to improve
-                     contrast against the dark background. -->
+                <!-- Filter bar: provides a group selector and displays EPG counts. -->
                 <DockPanel Margin="0,0,0,8" Grid.Row="0">
                     <!-- Group filter on the left -->
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Margin="0,0,8,0">
@@ -83,31 +96,14 @@
                                   BorderBrush="{DynamicResource DividerBrush}"
                                   BorderThickness="1"/>
                     </StackPanel>
-                    <!-- Clear button on the right -->
-                    <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Margin="8,0,0,0">
-                        <Button Content="Clear"
-                                Click="ClearSearch_Click"
-                                Style="{DynamicResource AccentButton}"/>
-                    </StackPanel>
-                <!-- EPG counters: displays how many channels and programmes were loaded and mapped.  
-                     Placed on the right side of the filter bar.  Hidden until EPG is loaded. -->
-                <TextBlock x:Name="EpgCountersText"
-                           DockPanel.Dock="Right"
-                           Margin="8,0,0,0"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource TextBrush}"
-                           Text="EPG: (waiting…)"
-                           ToolTip="Shows counts after EPG loads"/>
-                    <!-- Search box fills the remaining space -->
-                    <TextBox x:Name="SearchBox"
-                             Margin="0,0,8,0"
-                             VerticalAlignment="Center"
-                             HorizontalAlignment="Stretch"
-                             TextChanged="SearchBox_TextChanged"
-                             Background="{DynamicResource SurfaceBrush}"
-                             Foreground="{DynamicResource TextBrush}"
-                             BorderBrush="{DynamicResource DividerBrush}"
-                             BorderThickness="1"/>
+                    <!-- EPG counters: displays how many channels and programmes were loaded and mapped. -->
+                    <TextBlock x:Name="EpgCountersText"
+                               DockPanel.Dock="Right"
+                               Margin="8,0,0,0"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource TextBrush}"
+                               Text="EPG: (waiting…)"
+                               ToolTip="Shows counts after EPG loads"/>
                 </DockPanel>
                 <!-- Channel list -->
                 <views:ChannelListView x:Name="ChannelList" Grid.Row="1"

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -204,7 +204,7 @@ namespace WaxIPTV.Views
             else
             {
                 SelectedChannelTitle.Text = string.Empty;
-                NowNext.UpdateProgrammes(null, null);
+                NowNext.UpdateProgrammes(null);
             }
 
             // Start or restart the Now/Next timer
@@ -353,7 +353,7 @@ namespace WaxIPTV.Views
             else
             {
                 SelectedChannelTitle.Text = string.Empty;
-                NowNext.UpdateProgrammes(null, null);
+                NowNext.UpdateProgrammes(null);
             }
         }
 
@@ -799,20 +799,19 @@ namespace WaxIPTV.Views
             {
                 AppLog.Logger.Information("Channel selection cleared");
                 SelectedChannelTitle.Text = string.Empty;
-                NowNext.UpdateProgrammes(null, null);
+                NowNext.UpdateProgrammes(null);
                 return;
             }
             AppLog.Logger.Information("Channel selected {Name}", selected.Name);
             SelectedChannelTitle.Text = selected.Name;
             if (_programmes.TryGetValue(selected.Id, out var progs))
             {
-                var (now, next) = EpgHelpers.GetNowNext(progs, DateTimeOffset.UtcNow);
-                NowNext.UpdateProgrammes(now, next);
-                AppLog.Logger.Information("Now playing {Now} next {Next}", now?.Title, next?.Title);
+                NowNext.UpdateProgrammes(progs);
+                AppLog.Logger.Information("Loaded {Count} programmes for {Channel}", progs.Count, selected.Name);
             }
             else
             {
-                NowNext.UpdateProgrammes(null, null);
+                NowNext.UpdateProgrammes(null);
             }
         }
 
@@ -826,13 +825,12 @@ namespace WaxIPTV.Views
                 return;
             if (_programmes.TryGetValue(selected.Id, out var progs))
             {
-                var (now, next) = EpgHelpers.GetNowNext(progs, DateTimeOffset.UtcNow);
-                NowNext.UpdateProgrammes(now, next);
-                AppLog.Logger.Information("Updated Now/Next for {Channel}: {Now} -> {Next}", selected.Name, now?.Title, next?.Title);
+                NowNext.UpdateProgrammes(progs);
+                AppLog.Logger.Information("Updated EPG list for {Channel} with {Count} programmes", selected.Name, progs.Count);
             }
             else
             {
-                NowNext.UpdateProgrammes(null, null);
+                NowNext.UpdateProgrammes(null);
                 AppLog.Logger.Information("No EPG data for {Channel}", selected.Name);
             }
         }


### PR DESCRIPTION
## Summary
- display full programme schedules with descriptions in the Now/Next panel
- move channel search to a long bar in the main menu

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3b41cad28832e84159e306034c160