### PR TITLE
Enhance M3U parsing with logo and header support

### DIFF
--- a/Models/Channel.cs
+++ b/Models/Channel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace WaxIPTV.Models
 {
@@ -13,6 +14,7 @@ namespace WaxIPTV.Models
         string? Logo,
         string StreamUrl,
         string? TvgId = null,
-        string? TvgName = null
+        string? TvgName = null,
+        Dictionary<string, string>? Headers = null
     );
 }

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ handling.
   named pipe; VLC’s RC interface over TCP).  The choice of player and
   executable paths are defined in `settings.json`.
 - **Playlist and EPG:** M3U (including M3U8) playlist files are parsed
-  into a list of channels.  XMLTV feeds are loaded on a schedule, mapped
-  to channels using `tvg-id` or normalised names, and held in memory for
-  a few days.  A helper method computes the current and next programme for
-  a channel.
+  into a list of channels.  The parser understands custom logo lines
+  (`#EXTLOGO`) and special HTTP header directives (`#EXTVLCOPT:http-`,
+  `#KODIPROP:http-`) and preserves them for playback.  XMLTV feeds are
+  loaded on a schedule, mapped to channels using `tvg-id` or normalised
+  names, and held in memory for a few days.  A helper method computes the
+  current and next programme for a channel.
 - **Theming and layout:** A simple theming system reads colour, typography
   and shape tokens from `theme.json` and applies them at runtime via a
   helper (`ThemeLoader`).  A separate `layout.json` file hints which

--- a/Services/IPlayerControl.cs
+++ b/Services/IPlayerControl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace WaxIPTV.Services
 {
@@ -12,9 +13,9 @@ namespace WaxIPTV.Services
     public interface IPlayerControl : IAsyncDisposable
     {
         /// <summary>
-        /// Launches the player with the given stream URL and optional window title.
+        /// Launches the player with the given stream URL, optional window title and HTTP headers.
         /// </summary>
-        Task StartAsync(string url, string? title = null, CancellationToken ct = default);
+        Task StartAsync(string url, string? title = null, Dictionary<string, string>? headers = null, CancellationToken ct = default);
 
         /// <summary>
         /// Pauses or resumes playback.

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -410,9 +410,9 @@ namespace WaxIPTV.Views
                 // Provide placeholders when no channels loaded
                 channels = new List<Channel>
                 {
-                    new Channel("ch1", "Channel 1", null, null, "", null, null),
-                    new Channel("ch2", "Channel 2", null, null, "", null, null),
-                    new Channel("ch3", "Channel 3", null, null, "", null, null)
+                    new Channel("ch1", "Channel 1", null, null, "", null, null, null),
+                    new Channel("ch2", "Channel 2", null, null, "", null, null, null),
+                    new Channel("ch3", "Channel 3", null, null, "", null, null, null)
                 };
             }
             _channels = channels;
@@ -935,12 +935,12 @@ namespace WaxIPTV.Views
                 if (_player is MpvController mpv && mpv.IsRunning && _playerStarted)
                 {
                     AppLog.Logger.Information("Using existing mpv instance");
-                    await mpv.LoadAsync(ch.StreamUrl);
+                    await mpv.LoadAsync(ch.StreamUrl, ch.Headers);
                 }
                 else
                 {
                     AppLog.Logger.Information("Starting player process");
-                    await _player.StartAsync(ch.StreamUrl, ch.Name);
+                    await _player.StartAsync(ch.StreamUrl, ch.Name, ch.Headers);
                     _playerStarted = true;
                 }
             }


### PR DESCRIPTION
## Summary
- allow playlists to specify custom channel logos via `#EXTLOGO`
- parse `#EXTVLCOPT`/`#KODIPROP` HTTP headers and pass them to mpv/VLC
- extend player interface and channel model to carry optional headers

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3cf093178832e8d02464ae94d93a7