### PR TITLE
Add explicit EPG refresh controls and prevent unintended reloads

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -42,6 +42,8 @@ namespace WaxIPTV.ViewModels
         private string? playlistUrl;
         [ObservableProperty]
         private string? xmltvUrl;
+        [ObservableProperty]
+        private int epgRefreshHours = 12;
 
         // ----- Friendly Theme fields -----
         [ObservableProperty]
@@ -98,6 +100,7 @@ namespace WaxIPTV.ViewModels
             vlcPath     = settings.VlcPath;
             playlistUrl = settings.PlaylistUrl;
             xmltvUrl    = settings.XmltvUrl;
+            epgRefreshHours = settings.EpgRefreshHours;
 
             var themeFile = Path.Combine(AppContext.BaseDirectory, "theme.json");
             if (File.Exists(themeFile))
@@ -331,6 +334,7 @@ namespace WaxIPTV.ViewModels
             _settings.VlcPath     = vlcPath;
             _settings.PlaylistUrl = playlistUrl;
             _settings.XmltvUrl    = xmltvUrl;
+            _settings.EpgRefreshHours = epgRefreshHours;
 
             // Save settings and theme
             _service.Save(_settings);
@@ -339,12 +343,6 @@ namespace WaxIPTV.ViewModels
 
             // Apply the theme immediately
             ApplyTheme();
-
-            // If the user supplied an EPG source, trigger a download before closing
-            if (!string.IsNullOrWhiteSpace(xmltvUrl))
-            {
-                await DownloadEpg();
-            }
 
             try
             {
@@ -524,21 +522,6 @@ namespace WaxIPTV.ViewModels
         }
 
         /// <summary>
-        /// Forces a refresh of both the playlist and the EPG.  Invoked from
-        /// the settings dialog to allow users to immediately reparse and
-        /// reload their channels and EPG data after making changes.  If
-        /// the main window is not available, the method does nothing.
-        /// </summary>
-        [RelayCommand]
-        private async Task RefreshNow()
-        {
-            if (Application.Current.MainWindow is MainWindow mw)
-            {
-                await mw.RefreshFromSettingsAsync();
-            }
-        }
-
-        /// <summary>
         /// Forces a refresh of only the playlist using the current settings.  This
         /// command reloads the channel list without touching the cached EPG or
         /// triggering a new EPG download.  It is used when the user clicks
@@ -551,6 +534,20 @@ namespace WaxIPTV.ViewModels
             if (Application.Current.MainWindow is MainWindow mw)
             {
                 await mw.RefreshPlaylistFromSettingsAsync();
+            }
+        }
+
+        /// <summary>
+        /// Forces a refresh of only the EPG using the current settings.  This reloads the guide
+        /// data without reloading the playlist.  If the main window is not available, the method
+        /// does nothing.
+        /// </summary>
+        [RelayCommand]
+        private async Task RefreshEpg()
+        {
+            if (Application.Current.MainWindow is MainWindow mw)
+            {
+                await mw.RefreshEpgFromSettingsAsync();
             }
         }
     }

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -66,6 +66,7 @@
                         <RowDefinition Height="Auto"/> <!-- vlc path -->
                         <RowDefinition Height="Auto"/> <!-- playlist -->
                         <RowDefinition Height="Auto"/> <!-- EPG -->
+                        <RowDefinition Height="Auto"/> <!-- EPG refresh interval -->
                         <RowDefinition Height="Auto"/> <!-- EPG actions -->
                         <RowDefinition Height="*"/>  <!-- spacer row -->
                     </Grid.RowDefinitions>
@@ -142,11 +143,25 @@
                             Content="Browse…"
                             Command="{Binding BrowseEpgCommand}"/>
 
+                    <!-- EPG refresh interval -->
+                    <TextBlock Text="EPG refresh (hours)"
+                               Grid.Row="5" Grid.Column="0"
+                               Margin="0,0,8,8"
+                               VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="5" Grid.Column="1"
+                             Margin="0,0,8,8"
+                             Width="60"
+                             Text="{Binding EpgRefreshHours, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
                     <!-- EPG management buttons -->
-                    <StackPanel Grid.Row="5" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="0,6,0,0">
+                    <StackPanel Grid.Row="6" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="0,6,0,0">
                         <Button Content="Download EPG"
                                 ToolTip="Download and cache the EPG file locally"
                                 Command="{Binding DownloadEpgCommand}"/>
+                        <Button Content="Refresh EPG"
+                                Margin="6,0,0,0"
+                                ToolTip="Reload the EPG now"
+                                Command="{Binding RefreshEpgCommand}"/>
                         <!-- Refresh only the playlist without reloading EPG -->
                         <Button Content="Refresh playlist"
                                 Margin="6,0,0,0"
@@ -154,7 +169,7 @@
                                 Command="{Binding RefreshPlaylistCommand}"/>
                     </StackPanel>
                     <!-- Spacer row for expansion and EPG download progress -->
-                    <StackPanel Grid.Row="6" Grid.ColumnSpan="3">
+                    <StackPanel Grid.Row="7" Grid.ColumnSpan="3">
                         <!-- Progress bar showing EPG download status.  It becomes
                              visible while the download is running and hides
                              automatically when complete.  The value is


### PR DESCRIPTION
## Summary
- stop reloading EPG when opening the guide
- allow setting EPG refresh interval and add refresh button in settings
- provide method to refresh EPG only and remove auto-download on save

## Testing
- `dotnet build` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*


------
https://chatgpt.com/codex/tasks/task_b_68a3fccd5ca8832eb70f5d43da52c0d9