### PR TITLE
Load EPG guide incrementally to improve responsiveness

### DIFF
--- a/Views/GuideWindow.xaml.cs
+++ b/Views/GuideWindow.xaml.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
+using System.Threading.Tasks;
 using WaxIPTV.EpgGuide;
 using WaxIPTV.Models;
 
@@ -15,29 +15,10 @@ namespace WaxIPTV.Views
         {
             InitializeComponent();
 
-            var snapshot = new EpgSnapshot
+            Loaded += async (_, __) =>
             {
-                Channels = channels.Select((c, i) => new ChannelMeta
-                {
-                    TvgId = c.Id,
-                    Number = (i + 1).ToString(),
-                    Name = c.Name,
-                    Group = c.Group,
-                    LogoPath = c.Logo
-                }).ToArray(),
-                Programs = programmes.SelectMany(kv => kv.Value.Select(p => new ProgramBlock
-                {
-                    ChannelTvgId = kv.Key,
-                    Title = p.Title,
-                    Synopsis = p.Desc,
-                    StartUtc = p.StartUtc.UtcDateTime,
-                    EndUtc = p.EndUtc.UtcDateTime,
-                    IsLive = false,
-                    IsNew = false
-                })).ToArray()
+                await ((GuideViewModel)Guide.DataContext).LoadIncrementalAsync(channels, programmes);
             };
-
-            ((GuideViewModel)Guide.DataContext).LoadFrom(snapshot);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Load EPG channels/programs incrementally with async batches to keep UI responsive
- Initialize guide window by asynchronously filling data instead of building full snapshot

## Testing
- `dotnet build` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*


------
https://chatgpt.com/codex/tasks/task_b_68a41e7ef1f4832ea7f36495baecc5bf