### PR TITLE
Use preloaded EPG snapshot for guide

### DIFF
--- a/EpgGuide/ViewModels/GuideViewModel.cs
+++ b/EpgGuide/ViewModels/GuideViewModel.cs
@@ -115,7 +115,7 @@ public sealed class GuideViewModel : INotifyPropertyChanged
         VisibleStartUtc = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute < 30 ? 0 : 30, 0, DateTimeKind.Utc).AddMinutes(-30);
     }
 
-    public void LoadFrom(EpgSnapshot snapshot)
+    public async Task LoadFrom(EpgSnapshot snapshot)
     {
         Channels.Clear();
         FilteredChannels.Clear();
@@ -124,6 +124,7 @@ public sealed class GuideViewModel : INotifyPropertyChanged
             .GroupBy(p => p.ChannelTvgId)
             .ToDictionary(g => g.Key, g => g.OrderBy(p => p.StartUtc));
 
+        int i = 0;
         foreach (var ch in snapshot.Channels)
         {
             var row = new ChannelRow
@@ -142,6 +143,11 @@ public sealed class GuideViewModel : INotifyPropertyChanged
             }
 
             Channels.Add(row);
+            FilteredChannels.Add(row);
+
+            i++;
+            if (i % 20 == 0)
+                await Task.Yield();
         }
 
         Groups.Clear();

--- a/Views/GuideWindow.xaml.cs
+++ b/Views/GuideWindow.xaml.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
-using System.Windows;
 using System.Threading.Tasks;
+using System.Windows;
 using WaxIPTV.EpgGuide;
-using WaxIPTV.Models;
 
 namespace WaxIPTV.Views
 {
@@ -11,13 +9,13 @@ namespace WaxIPTV.Views
     /// </summary>
     public partial class GuideWindow : Window
     {
-        public GuideWindow(List<Channel> channels, Dictionary<string, List<Programme>> programmes)
+        public GuideWindow(EpgSnapshot snapshot)
         {
             InitializeComponent();
 
             Loaded += async (_, __) =>
             {
-                await ((GuideViewModel)Guide.DataContext).LoadIncrementalAsync(channels, programmes);
+                await ((GuideViewModel)Guide.DataContext).LoadFrom(snapshot);
             };
         }
     }


### PR DESCRIPTION
## Summary
- reuse preloaded channel and EPG data when opening the guide
- build a reusable EPG snapshot after XMLTV mapping to avoid heavy recomputation
- add async loader for guide that populates from the snapshot incrementally

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop". The SDK 'Microsoft.NET.Sdk.WindowsDesktop' specified could not be found.)*

------
https://chatgpt.com/codex/tasks/task_b_68a64fd26834832e8b1ef483d434263a