### PR TITLE
Allow guide to open while EPG loads

### DIFF
--- a/Views/GuideWindow.xaml.cs
+++ b/Views/GuideWindow.xaml.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows;
 using WaxIPTV.EpgGuide;
+using WaxIPTV.Models;
 
 namespace WaxIPTV.Views
 {
@@ -9,14 +11,23 @@ namespace WaxIPTV.Views
     /// </summary>
     public partial class GuideWindow : Window
     {
-        public GuideWindow(EpgSnapshot snapshot)
+        public GuideWindow(EpgSnapshot? snapshot, IList<Channel> channels, Dictionary<string, List<Programme>> programmes)
         {
             InitializeComponent();
+            Loaded += async (_, __) => { await LoadData(snapshot, channels, programmes); };
+        }
 
-            Loaded += async (_, __) =>
+        public async Task LoadData(EpgSnapshot? snapshot, IList<Channel> channels, Dictionary<string, List<Programme>> programmes)
+        {
+            var vm = (GuideViewModel)Guide.DataContext;
+            if (snapshot != null)
             {
-                await ((GuideViewModel)Guide.DataContext).LoadFrom(snapshot);
-            };
+                await vm.LoadFrom(snapshot);
+            }
+            else
+            {
+                await vm.LoadIncrementalAsync(channels, programmes);
+            }
         }
     }
 }

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace WaxIPTV.Views
         private List<Channel> _channels = new();
         private Dictionary<string, List<Programme>> _programmes = new();
         private EpgSnapshot? _epgSnapshot;
+        private GuideWindow? _guideWindow;
         private DateTimeOffset _epgLoadedAt = DateTimeOffset.MinValue;
         // Timer used to refresh the Now/Next display on a fixed schedule.
         private System.Windows.Threading.DispatcherTimer? _nowNextTimer;
@@ -843,6 +844,11 @@ namespace WaxIPTV.Views
                 AppLog.Logger.Warning(ex, "Failed to update EPG UI after load");
                 // ignore UI update errors
             }
+
+            if (_guideWindow != null)
+            {
+                await _guideWindow.LoadData(_epgSnapshot, _channels, _programmes);
+            }
         }
 
         private static EpgSnapshot BuildEpgSnapshot(IList<Channel> channels, Dictionary<string, List<Programme>> programmes)
@@ -1241,17 +1247,19 @@ namespace WaxIPTV.Views
         /// </summary>
         private void GuideMenu_Click(object sender, RoutedEventArgs e)
         {
-            if (_epgSnapshot == null)
+            if (_guideWindow == null)
             {
-                MessageBox.Show("EPG data is not loaded yet.", "EPG Guide", MessageBoxButton.OK, MessageBoxImage.Information);
-                return;
+                _guideWindow = new GuideWindow(_epgSnapshot, _channels, _programmes)
+                {
+                    Owner = this
+                };
+                _guideWindow.Closed += (_, __) => _guideWindow = null;
+                _guideWindow.Show();
             }
-
-            var guide = new GuideWindow(_epgSnapshot)
+            else
             {
-                Owner = this
-            };
-            guide.Show();
+                _guideWindow.Activate();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Allow opening the guide window even when EPG data is still loading
- Provide a method to reload guide data and update the open guide after EPG completes

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a651cf5bb8832ead8e089e1398ba9f