### PR TITLE
Load EPG guide incrementally

### DIFF
--- a/Views/GuideWindow.xaml.cs
+++ b/Views/GuideWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using WaxIPTV.EpgGuide;
 
@@ -16,10 +17,10 @@ namespace WaxIPTV.Views
             InitializeComponent();
             _parent = parent;
 
-            Loaded += (_, __) =>
+            Loaded += async (_, __) =>
             {
                 if (parent.CurrentEpgSnapshot != null)
-                    ((GuideViewModel)Guide.DataContext).LoadFrom(parent.CurrentEpgSnapshot);
+                    await ((GuideViewModel)Guide.DataContext).LoadFromAsync(parent.CurrentEpgSnapshot);
             };
 
             parent.EpgSnapshotUpdated += Parent_EpgSnapshotUpdated;
@@ -28,8 +29,8 @@ namespace WaxIPTV.Views
 
         private void Parent_EpgSnapshotUpdated(EpgSnapshot snapshot)
         {
-            Dispatcher.Invoke(() =>
-                ((GuideViewModel)Guide.DataContext).LoadFrom(snapshot));
+            Dispatcher.InvokeAsync(async () =>
+                await ((GuideViewModel)Guide.DataContext).LoadFromAsync(snapshot));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Load EPG guide data asynchronously and yield during channel population
- Update guide window to await incremental loading and refresh on snapshot updates

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop". The SDK 'Microsoft.NET.Sdk.WindowsDesktop' specified could not be found.)*

------
https://chatgpt.com/codex/tasks/task_b_68a667ec8c74832e9a2a81f78bd3e52f