### PR TITLE
Add EPG guide window with timeline and playback

### DIFF
--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -1,0 +1,108 @@
+<Window x:Class="WaxIPTV.Views.EpgGuideWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="EPG Guide"
+        Height="600"
+        Width="1000"
+        Background="{DynamicResource BgBrush}"
+        Foreground="{DynamicResource TextBrush}">
+    <!--
+        Displays a programme guide timeline for all channels.  A search box and
+        group selector allow filtering.  Selecting a programme shows its
+        details in the header with a Play button.
+    -->
+    <DockPanel>
+        <!-- Detail panel -->
+        <Border DockPanel.Dock="Top"
+                Background="{DynamicResource SurfaceBrush}"
+                CornerRadius="{DynamicResource ThemeCornerRadius}"
+                Margin="8"
+                Padding="8">
+            <StackPanel Orientation="Vertical">
+                <TextBlock x:Name="DetailTitle" FontWeight="Bold" FontSize="16"/>
+                <TextBlock x:Name="DetailTime" Margin="0,2,0,0"/>
+                <TextBlock x:Name="DetailDesc" TextWrapping="Wrap" Margin="0,2,0,8"/>
+                <Button x:Name="PlayProgrammeButton" Content="Play" Width="80" Click="PlayProgrammeButton_Click" Style="{DynamicResource AccentButton}" Visibility="Collapsed"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Filter bar -->
+        <DockPanel DockPanel.Dock="Top" Margin="8">
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Margin="0,0,8,0">
+                <TextBlock Text="Group" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <ComboBox x:Name="GroupFilter" Width="160"
+                          SelectionChanged="GroupFilter_SelectionChanged"
+                          Background="{DynamicResource DropdownBrush}"
+                          Foreground="{DynamicResource TextBrush}"
+                          BorderBrush="{DynamicResource DividerBrush}"
+                          BorderThickness="1"/>
+            </StackPanel>
+            <TextBox x:Name="SearchBox" DockPanel.Dock="Right" Width="300" Margin="8,0,0,0"
+                     TextChanged="SearchBox_TextChanged"
+                     Background="{DynamicResource SurfaceBrush}"
+                     Foreground="{DynamicResource TextBrush}"
+                     BorderBrush="{DynamicResource DividerBrush}"
+                     BorderThickness="1"/>
+        </DockPanel>
+
+        <!-- Timeline header showing hour markers -->
+        <ScrollViewer DockPanel.Dock="Top" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" Margin="8,0,8,4">
+            <ItemsControl x:Name="TimelineHeader">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Canvas Height="20" Width="720"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Label}" Canvas.Left="{Binding Left}" FontSize="12"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+        <!-- Main channel/programme timeline list -->
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Margin="8">
+            <ItemsControl x:Name="ChannelItems">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Margin="0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="160"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <!-- Channel info -->
+                            <StackPanel Orientation="Horizontal" Grid.Column="0">
+                                <Image Source="{Binding Channel.Logo}" Width="24" Height="24" Margin="0,0,6,0"/>
+                                <TextBlock Text="{Binding Channel.Name}" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <!-- Programme timeline -->
+                            <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
+                                <ItemsControl ItemsSource="{Binding Blocks}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <Canvas Height="40" Width="720"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Background="{DynamicResource SurfaceBrush}"
+                                                    BorderBrush="{DynamicResource DividerBrush}"
+                                                    BorderThickness="1"
+                                                    Canvas.Left="{Binding Left}"
+                                                    Width="{Binding Width}"
+                                                    Height="40"
+                                                    MouseLeftButtonUp="ProgrammeBlock_MouseLeftButtonUp">
+                                                <TextBlock Text="{Binding Programme.Title}" TextWrapping="Wrap"/>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using WaxIPTV.Models;
+
+namespace WaxIPTV.Views
+{
+    /// <summary>
+    /// Window displaying an EPG timeline for all channels.  A search box and
+    /// group selector allow filtering.  Selecting a programme shows details in
+    /// the header with a Play button to start playback via a callback provided
+    /// by the main window.
+    /// </summary>
+    public partial class EpgGuideWindow : Window
+    {
+        private readonly List<Channel> _channels;
+        private readonly Dictionary<string, List<Programme>> _programmes;
+        private readonly Func<Channel, Task>? _playCallback;
+        private readonly DateTimeOffset _startUtc;
+        private readonly DateTimeOffset _endUtc;
+
+        private string _searchTerm = string.Empty;
+        private string? _selectedGroup;
+        private Channel? _selectedChannel;
+        private Programme? _selectedProgramme;
+
+        public EpgGuideWindow(List<Channel> channels,
+                              Dictionary<string, List<Programme>> programmes,
+                              Func<Channel, Task>? playCallback = null)
+        {
+            InitializeComponent();
+            _channels = channels;
+            _programmes = programmes;
+            _playCallback = playCallback;
+            _startUtc = DateTimeOffset.UtcNow;
+            _endUtc = _startUtc.AddHours(12);
+
+            PopulateGroupFilter();
+            BuildTimelineHeader();
+            ApplyFilter();
+        }
+
+        private void PopulateGroupFilter()
+        {
+            var groups = _channels
+                .Select(c => string.IsNullOrWhiteSpace(c.Group) ? "Ungrouped" : c.Group!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g)
+                .ToList();
+            groups.Insert(0, "All");
+            GroupFilter.ItemsSource = groups;
+            GroupFilter.SelectedIndex = 0;
+        }
+
+        private void BuildTimelineHeader()
+        {
+            var items = new List<TimelineHeaderItem>();
+            var localStart = _startUtc.ToLocalTime();
+            for (int i = 0; i <= 12; i++)
+            {
+                var t = localStart.AddHours(i);
+                items.Add(new TimelineHeaderItem
+                {
+                    Left = i * 60,
+                    Label = t.ToString("HH:mm")
+                });
+            }
+            TimelineHeader.ItemsSource = items;
+        }
+
+        private void SearchBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            _searchTerm = SearchBox.Text ?? string.Empty;
+            ApplyFilter();
+        }
+
+        private void GroupFilter_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _selectedGroup = GroupFilter.SelectedItem as string;
+            ApplyFilter();
+        }
+
+        private void ApplyFilter()
+        {
+            IEnumerable<Channel> filtered = _channels;
+
+            if (!string.IsNullOrEmpty(_searchTerm))
+            {
+                var term = _searchTerm;
+                filtered = filtered.Where(ch =>
+                    (!string.IsNullOrEmpty(ch.Name) && ch.Name.Contains(term, StringComparison.OrdinalIgnoreCase)) ||
+                    (!string.IsNullOrEmpty(ch.TvgId) && ch.TvgId.Contains(term, StringComparison.OrdinalIgnoreCase)) ||
+                    (!string.IsNullOrEmpty(ch.Group) && ch.Group.Contains(term, StringComparison.OrdinalIgnoreCase)));
+            }
+
+            if (!string.IsNullOrWhiteSpace(_selectedGroup) && !string.Equals(_selectedGroup, "All", StringComparison.OrdinalIgnoreCase))
+            {
+                var sel = _selectedGroup;
+                filtered = filtered.Where(ch => string.Equals(ch.Group ?? "Ungrouped", sel, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var rows = filtered
+                .Select(ch => new ChannelEpgRow
+                {
+                    Channel = ch,
+                    Blocks = BuildBlocks(ch)
+                })
+                .ToList();
+
+            ChannelItems.ItemsSource = rows;
+        }
+
+        private List<EpgBlock> BuildBlocks(Channel ch)
+        {
+            var blocks = new List<EpgBlock>();
+            if (!_programmes.TryGetValue(ch.Id, out var list))
+                return blocks;
+            foreach (var prog in list)
+            {
+                if (prog.EndUtc <= _startUtc || prog.StartUtc >= _endUtc)
+                    continue;
+                var start = prog.StartUtc < _startUtc ? _startUtc : prog.StartUtc;
+                var end = prog.EndUtc > _endUtc ? _endUtc : prog.EndUtc;
+                var left = (start - _startUtc).TotalMinutes;
+                var width = (end - start).TotalMinutes;
+                blocks.Add(new EpgBlock { Channel = ch, Programme = prog, Left = left, Width = width });
+            }
+            return blocks;
+        }
+
+        private void ProgrammeBlock_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement fe && fe.DataContext is EpgBlock block)
+            {
+                _selectedProgramme = block.Programme;
+                _selectedChannel = block.Channel;
+                UpdateDetails();
+            }
+        }
+
+        private async void PlayProgrammeButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_selectedChannel != null && _playCallback != null)
+            {
+                await _playCallback(_selectedChannel);
+            }
+        }
+
+        private void UpdateDetails()
+        {
+            if (_selectedProgramme != null && _selectedChannel != null)
+            {
+                DetailTitle.Text = _selectedProgramme.Title + " (" + _selectedChannel.Name + ")";
+                var localStart = _selectedProgramme.StartUtc.ToLocalTime();
+                var localEnd = _selectedProgramme.EndUtc.ToLocalTime();
+                DetailTime.Text = $"{localStart:HH:mm} - {localEnd:HH:mm}";
+                DetailDesc.Text = _selectedProgramme.Desc ?? string.Empty;
+                PlayProgrammeButton.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                DetailTitle.Text = string.Empty;
+                DetailTime.Text = string.Empty;
+                DetailDesc.Text = string.Empty;
+                PlayProgrammeButton.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private sealed class ChannelEpgRow
+        {
+            public required Channel Channel { get; init; }
+            public required List<EpgBlock> Blocks { get; init; }
+        }
+
+        private sealed class EpgBlock
+        {
+            public required Channel Channel { get; init; }
+            public required Programme Programme { get; init; }
+            public double Left { get; init; }
+            public double Width { get; init; }
+        }
+
+        private sealed class TimelineHeaderItem
+        {
+            public double Left { get; init; }
+            public required string Label { get; init; }
+        }
+    }
+}

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -23,6 +23,11 @@
         <DockPanel DockPanel.Dock="Top" Margin="0,0,0,4">
             <!-- Shortcut buttons on the left -->
             <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" Margin="0,0,8,0">
+                <!-- EPG guide button -->
+                <Button Width="32" Height="32" ToolTip="EPG Guide"
+                        Click="EpgGuide_Click" Style="{DynamicResource AccentButton}">
+                    <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="16" Text="&#xE12B;"/>
+                </Button>
                 <!-- Settings button -->
                 <Button Width="32" Height="32" ToolTip="Settings"
                         Click="SettingsMenu_Click" Style="{DynamicResource AccentButton}">

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -1025,6 +1025,20 @@ namespace WaxIPTV.Views
         }
 
         /// <summary>
+        /// Opens the EPG guide window displaying the timeline for all channels.
+        /// </summary>
+        private void EpgGuide_Click(object sender, RoutedEventArgs e)
+        {
+            var guide = new EpgGuideWindow(_channels, _programmes, PlayChannelFromGuideAsync)
+            {
+                Owner = this
+            };
+            guide.Show();
+        }
+
+        private System.Threading.Tasks.Task PlayChannelFromGuideAsync(Channel ch) => PlayChannelAsync(ch);
+
+        /// <summary>
         /// Pause button handler.  Toggles pause on the active player.
         /// </summary>
         private async void PauseButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Add EPG guide window showing 12-hour timeline per channel with search and group filtering
- Include detail panel with play button for selected programme
- Add EPG Guide button to main window to open the new guide

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_b_68a66ce280e4832e8a23b26973756d15