### PR TITLE
Fix EPG guide layout rendering

### DIFF
--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="WaxIPTV.Views.EpgGuideWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:WaxIPTV.Views"
         Title="EPG Guide"
         Height="600"
         Width="1000"
@@ -47,10 +48,10 @@
 
         <!-- Timeline header showing hour markers -->
         <ScrollViewer DockPanel.Dock="Top" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" Margin="8,0,8,4">
-            <ItemsControl x:Name="TimelineHeader">
+            <ItemsControl x:Name="TimelineHeader" Width="{x:Static local:EpgGuideWindow.TimelineWidth}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <Canvas Height="20" Width="720"/>
+                        <Canvas Height="20"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
@@ -78,10 +79,10 @@
                             </StackPanel>
                             <!-- Programme timeline -->
                             <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
-                                <ItemsControl ItemsSource="{Binding Blocks}">
+                                <ItemsControl ItemsSource="{Binding Blocks}" Width="{x:Static local:EpgGuideWindow.TimelineWidth}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
-                                            <Canvas Height="40" Width="720"/>
+                                            <Canvas Height="40"/>
                                         </ItemsPanelTemplate>
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>

--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -19,6 +19,10 @@ namespace WaxIPTV.Views
     /// </summary>
     public partial class EpgGuideWindow : Window
     {
+        private const int TimelineHours = 12;
+        private const double PixelsPerMinute = 2.0;
+        public static readonly double TimelineWidth = TimelineHours * 60 * PixelsPerMinute;
+
         private readonly List<Channel> _channels;
         private readonly Dictionary<string, List<Programme>> _programmes;
         private readonly Func<Channel, Task>? _playCallback;
@@ -42,7 +46,7 @@ namespace WaxIPTV.Views
             _programmes = programmes;
             _playCallback = playCallback;
             _startUtc = DateTimeOffset.UtcNow;
-            _endUtc = _startUtc.AddHours(12);
+            _endUtc = _startUtc.AddHours(TimelineHours);
 
             ChannelItems.ItemsSource = _rows;
             PopulateGroupFilter();
@@ -66,12 +70,12 @@ namespace WaxIPTV.Views
         {
             var items = new List<TimelineHeaderItem>();
             var localStart = _startUtc.ToLocalTime();
-            for (int i = 0; i <= 12; i++)
+            for (int i = 0; i <= TimelineHours; i++)
             {
                 var t = localStart.AddHours(i);
                 items.Add(new TimelineHeaderItem
                 {
-                    Left = i * 60,
+                    Left = i * 60 * PixelsPerMinute,
                     Label = t.ToString("HH:mm")
                 });
             }
@@ -154,8 +158,8 @@ namespace WaxIPTV.Views
                     continue;
                 var start = prog.StartUtc < _startUtc ? _startUtc : prog.StartUtc;
                 var end = prog.EndUtc > _endUtc ? _endUtc : prog.EndUtc;
-                var left = (start - _startUtc).TotalMinutes;
-                var width = (end - start).TotalMinutes;
+                var left = (start - _startUtc).TotalMinutes * PixelsPerMinute;
+                var width = (end - start).TotalMinutes * PixelsPerMinute;
                 blocks.Add(new EpgBlock { Channel = ch, Programme = prog, Left = left, Width = width });
             }
             return blocks;


### PR DESCRIPTION
## Summary
- widen EPG timeline to prevent overlapping program boxes and time labels
- scale program positions by minutes to align with 12-hour window

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_b_68a671547ba4832eb354397ce1c9b520