### PR TITLE
Improve EPG tile layout and pixel alignment

### DIFF
--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -6,7 +6,9 @@
         Height="600"
         Width="1000"
         Background="{DynamicResource BgBrush}"
-        Foreground="{DynamicResource TextBrush}">
+        Foreground="{DynamicResource TextBrush}"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
     <!--
         Displays a programme guide timeline for all channels.  A search box and
         group selector allow filtering.  Selecting a programme shows its
@@ -48,7 +50,7 @@
 
         <!-- Timeline header showing hour markers -->
         <ScrollViewer DockPanel.Dock="Top" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" Margin="8,0,8,4">
-            <ItemsControl x:Name="TimelineHeader" Width="{x:Static local:EpgGuideWindow.TimelineWidth}">
+            <ItemsControl x:Name="TimelineHeader" Width="{x:Static local:EpgGuideWindow.TimelineWidth}" SnapsToDevicePixels="True" UseLayoutRounding="True">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
                         <Canvas Height="20"/>
@@ -64,7 +66,7 @@
 
         <!-- Main channel/programme timeline list -->
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Margin="8">
-            <ItemsControl x:Name="ChannelItems">
+            <ItemsControl x:Name="ChannelItems" SnapsToDevicePixels="True" UseLayoutRounding="True">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Grid Margin="0,2">
@@ -79,10 +81,10 @@
                             </StackPanel>
                             <!-- Programme timeline -->
                             <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
-                                <ItemsControl ItemsSource="{Binding Blocks}" Width="{x:Static local:EpgGuideWindow.TimelineWidth}">
+                                <ItemsControl ItemsSource="{Binding Blocks}" Width="{x:Static local:EpgGuideWindow.TimelineWidth}" SnapsToDevicePixels="True" UseLayoutRounding="True">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
-                                            <Canvas Height="40"/>
+                                            <Canvas Height="40" SnapsToDevicePixels="True" UseLayoutRounding="True"/>
                                         </ItemsPanelTemplate>
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
@@ -93,9 +95,26 @@
                                                     Canvas.Left="{Binding Left}"
                                                     Width="{Binding Width}"
                                                     Height="40"
-                                                    MouseLeftButtonUp="ProgrammeBlock_MouseLeftButtonUp">
-                                                <TextBlock Text="{Binding Programme.Title}" TextWrapping="Wrap"/>
+                                                    Padding="4,0"
+                                                    MouseLeftButtonUp="ProgrammeBlock_MouseLeftButtonUp"
+                                                    ToolTip="{Binding Tooltip}" SnapsToDevicePixels="True">
+                                                <Grid>
+                                                    <TextBlock x:Name="TitleText"
+                                                               Text="{Binding Programme.Title}"
+                                                               TextWrapping="NoWrap"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               VerticalAlignment="Center"
+                                                               Margin="0"
+                                                               FontSize="12"/>
+                                                    <Image x:Name="LogoImage" Source="{Binding Channel.Logo}" Width="16" Height="16" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Collapsed"/>
+                                                </Grid>
                                             </Border>
+                                            <DataTemplate.Triggers>
+                                                <DataTrigger Binding="{Binding ShowTitle}" Value="False">
+                                                    <Setter TargetName="TitleText" Property="Visibility" Value="Collapsed"/>
+                                                    <Setter TargetName="LogoImage" Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </DataTemplate.Triggers>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>

--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace WaxIPTV.Views
     {
         private const int TimelineHours = 12;
         private const double PixelsPerMinute = 2.0;
+        private const double MinBlockWidth = 20.0;
         public static readonly double TimelineWidth = TimelineHours * 60 * PixelsPerMinute;
 
         private readonly List<Channel> _channels;
@@ -75,7 +76,7 @@ namespace WaxIPTV.Views
                 var t = localStart.AddHours(i);
                 items.Add(new TimelineHeaderItem
                 {
-                    Left = i * 60 * PixelsPerMinute,
+                    Left = Math.Round(i * 60 * PixelsPerMinute),
                     Label = t.ToString("HH:mm")
                 });
             }
@@ -160,7 +161,22 @@ namespace WaxIPTV.Views
                 var end = prog.EndUtc > _endUtc ? _endUtc : prog.EndUtc;
                 var left = (start - _startUtc).TotalMinutes * PixelsPerMinute;
                 var width = (end - start).TotalMinutes * PixelsPerMinute;
-                blocks.Add(new EpgBlock { Channel = ch, Programme = prog, Left = left, Width = width });
+                var right = left + width;
+                var leftRounded = Math.Round(left);
+                var rightRounded = Math.Round(right);
+                var widthRounded = rightRounded - leftRounded;
+                var displayWidth = Math.Max(widthRounded, MinBlockWidth);
+                var showTitle = widthRounded >= MinBlockWidth;
+                var tooltip = $"{prog.Title}\n{prog.StartUtc.ToLocalTime():HH:mm} - {prog.EndUtc.ToLocalTime():HH:mm}";
+                blocks.Add(new EpgBlock
+                {
+                    Channel = ch,
+                    Programme = prog,
+                    Left = leftRounded,
+                    Width = displayWidth,
+                    ShowTitle = showTitle,
+                    Tooltip = tooltip
+                });
             }
             return blocks;
         }
@@ -215,6 +231,8 @@ namespace WaxIPTV.Views
             public required Programme Programme { get; init; }
             public double Left { get; init; }
             public double Width { get; init; }
+            public bool ShowTitle { get; init; }
+            public required string Tooltip { get; init; }
         }
 
         private sealed class TimelineHeaderItem


### PR DESCRIPTION
## Summary
- keep EPG tiles crisp by enabling layout rounding and device-pixel snapping
- truncate programme titles with ellipsis and show channel logo when tiles are too narrow
- round tile positions, clamp widths to a minimum and provide full details via tooltip

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_b_68a67c33e764832e8f99a075a6db332a