### PR TITLE
Improve EPG tile layout for clarity and pixel alignment

### DIFF
--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -6,7 +6,9 @@
         Height="600"
         Width="1000"
         Background="{DynamicResource BgBrush}"
-        Foreground="{DynamicResource TextBrush}">
+        Foreground="{DynamicResource TextBrush}"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True">
     <!--
         Displays a programme guide timeline for all channels.  A search box and
         group selector allow filtering.  Selecting a programme shows its
@@ -48,10 +50,10 @@
 
         <!-- Timeline header showing hour markers -->
         <ScrollViewer DockPanel.Dock="Top" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Hidden" Margin="8,0,8,4">
-            <ItemsControl x:Name="TimelineHeader" Width="{x:Static local:EpgGuideWindow.TimelineWidth}">
+            <ItemsControl x:Name="TimelineHeader" Width="{x:Static local:EpgGuideWindow.TimelineWidth}" UseLayoutRounding="True" SnapsToDevicePixels="True">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
-                        <Canvas Height="20"/>
+                        <Canvas Height="20" UseLayoutRounding="True" SnapsToDevicePixels="True"/>
                     </ItemsPanelTemplate>
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
@@ -64,7 +66,7 @@
 
         <!-- Main channel/programme timeline list -->
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" Margin="8">
-            <ItemsControl x:Name="ChannelItems">
+            <ItemsControl x:Name="ChannelItems" UseLayoutRounding="True" SnapsToDevicePixels="True">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Grid Margin="0,2">
@@ -79,10 +81,10 @@
                             </StackPanel>
                             <!-- Programme timeline -->
                             <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
-                                <ItemsControl ItemsSource="{Binding Blocks}" Width="{x:Static local:EpgGuideWindow.TimelineWidth}">
+                                <ItemsControl ItemsSource="{Binding Blocks}" Width="{x:Static local:EpgGuideWindow.TimelineWidth}" UseLayoutRounding="True" SnapsToDevicePixels="True">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
-                                            <Canvas Height="40"/>
+                                            <Canvas Height="40" UseLayoutRounding="True" SnapsToDevicePixels="True"/>
                                         </ItemsPanelTemplate>
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
@@ -93,8 +95,23 @@
                                                     Canvas.Left="{Binding Left}"
                                                     Width="{Binding Width}"
                                                     Height="40"
+                                                    Padding="4,0"
+                                                    ToolTip="{Binding ToolTip}"
+                                                    SnapsToDevicePixels="True"
                                                     MouseLeftButtonUp="ProgrammeBlock_MouseLeftButtonUp">
-                                                <TextBlock Text="{Binding Programme.Title}" TextWrapping="Wrap"/>
+                                                <Grid>
+                                                    <TextBlock Text="{Binding Programme.Title}"
+                                                               TextWrapping="NoWrap"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               VerticalAlignment="Center"
+                                                               FontSize="12"
+                                                               Visibility="{Binding TextVisibility}"/>
+                                                    <Image Source="{Binding Channel.Logo}"
+                                                           Width="16" Height="16"
+                                                           HorizontalAlignment="Center"
+                                                           VerticalAlignment="Center"
+                                                           Visibility="{Binding LogoVisibility}"/>
+                                                </Grid>
                                             </Border>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- align EPG tiles to device pixels and use layout rounding
- clamp programme widths with minimum size, hiding titles on tiny blocks
- truncate programme titles with ellipsis and add tooltips with full details

## Testing
- `dotnet build` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_b_68a67c33e764832e8f99a075a6db332a