### PR TITLE
Slow down EPG guide channel loading

### DIFF
--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -130,21 +130,18 @@ namespace WaxIPTV.Views
 
         private async Task LoadRowsAsync(List<Channel> channels, CancellationToken token)
         {
-            const int batchSize = 20;
-            for (int i = 0; i < channels.Count; i += batchSize)
+            // Load channels one at a time with a long delay between each to
+            // reduce CPU usage when populating the EPG guide.
+            foreach (var ch in channels)
             {
                 token.ThrowIfCancellationRequested();
-                var batch = channels
-                    .Skip(i)
-                    .Take(batchSize)
-                    .Select(ch => new ChannelEpgRow
-                    {
-                        Channel = ch,
-                        Blocks = BuildBlocks(ch)
-                    });
-                foreach (var row in batch)
-                    _rows.Add(row);
-                await Task.Delay(100, token);
+                var row = new ChannelEpgRow
+                {
+                    Channel = ch,
+                    Blocks = BuildBlocks(ch)
+                };
+                _rows.Add(row);
+                await Task.Delay(1000, token); // load very slowly
             }
         }
 


### PR DESCRIPTION
## Summary
- Throttle EPG guide population by loading channels sequentially with a one-second delay to reduce CPU impact.

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop"; SDK not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af0a18c84c832e953b0a1df54b7885