### PR TITLE
Limit EPG data to six hours

### DIFF
--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -19,7 +19,7 @@ namespace WaxIPTV.Views
     /// </summary>
     public partial class EpgGuideWindow : Window
     {
-        private const int TimelineHours = 12;
+        private const int TimelineHours = 6;
         private const double PixelsPerMinute = 2.0;
         private const double MinBlockWidth = 20.0;
         public static readonly double TimelineWidth = Math.Round(TimelineHours * 60 * PixelsPerMinute);

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -687,11 +687,12 @@ namespace WaxIPTV.Views
                     });
                     programmesDict = EpgMapper.MapProgrammesInBatches(programmeStream, _channels, channelNames, 200, overrides, progress, programmesDict);
                     AppLog.Logger.Information("Mapping {ProgCount} programmes", totalProgrammes);
-                    // Trim programmes beyond 7 days to limit memory usage
-                    var cutoff = DateTimeOffset.UtcNow.AddDays(7);
+                    // Trim programmes outside the next 6 hours to limit memory usage
+                    var now = DateTimeOffset.UtcNow;
+                    var cutoff = now.AddHours(6);
                     foreach (var kv in programmesDict)
                     {
-                        kv.Value.RemoveAll(p => p.EndUtc > cutoff);
+                        kv.Value.RemoveAll(p => p.EndUtc <= now || p.StartUtc >= cutoff);
                     }
                     _epgLoadedAt = DateTimeOffset.UtcNow;
 


### PR DESCRIPTION
## Summary
- Restrict EPG mapping to only retain programmes within the next six hours, minimizing memory usage
- Reduce EPG guide timeline to six hours so fewer programme blocks are rendered

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af0e549f40832eb6e29c57a85853d8