### PR TITLE
Show placeholder when no programme selected in EPG

### DIFF
--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -54,13 +54,13 @@
                 CornerRadius="{DynamicResource ThemeCornerRadius}"
                 Padding="8"
                 Margin="8,0,8,0"
-                Visibility="Collapsed"
                 x:Name="InfoPanel">
             <StackPanel>
-                <TextBlock x:Name="InfoTitle" FontWeight="Bold" FontSize="16" Margin="0,0,0,4"/>
-                <TextBlock x:Name="InfoTime" Margin="0,0,0,4"/>
-                <TextBlock x:Name="InfoDesc" TextWrapping="Wrap" Margin="0,0,0,8"/>
-                <Button x:Name="InfoPlayButton" Content="Play" Width="80" Click="InfoPlayButton_Click" Style="{DynamicResource AccentButton}"/>
+                <TextBlock x:Name="InfoPlaceholder" Text="Select a programme to view details."/>
+                <TextBlock x:Name="InfoTitle" FontWeight="Bold" FontSize="16" Margin="0,0,0,4" Visibility="Collapsed"/>
+                <TextBlock x:Name="InfoTime" Margin="0,0,0,4" Visibility="Collapsed"/>
+                <TextBlock x:Name="InfoDesc" TextWrapping="Wrap" Margin="0,0,0,8" Visibility="Collapsed"/>
+                <Button x:Name="InfoPlayButton" Content="Play" Width="80" Click="InfoPlayButton_Click" Style="{DynamicResource AccentButton}" Visibility="Collapsed"/>
             </StackPanel>
         </Border>
 

--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -426,12 +426,25 @@ namespace WaxIPTV.Views
                 // Single click: show or hide programme info
                 if (seg.Programme == null)
                 {
-                    InfoPanel.Visibility = Visibility.Collapsed;
+                    InfoPanel.Visibility = Visibility.Visible;
+                    InfoPlaceholder.Visibility = Visibility.Visible;
+                    InfoTitle.Visibility = Visibility.Collapsed;
+                    InfoTime.Visibility = Visibility.Collapsed;
+                    InfoDesc.Visibility = Visibility.Collapsed;
+                    InfoPlayButton.Visibility = Visibility.Collapsed;
+                    InfoTitle.Text = string.Empty;
+                    InfoTime.Text = string.Empty;
+                    InfoDesc.Text = string.Empty;
                     InfoPlayButton.Tag = null;
                     return;
                 }
                 var prog = seg.Programme;
                 InfoPanel.Visibility = Visibility.Visible;
+                InfoPlaceholder.Visibility = Visibility.Collapsed;
+                InfoTitle.Visibility = Visibility.Visible;
+                InfoTime.Visibility = Visibility.Visible;
+                InfoDesc.Visibility = Visibility.Visible;
+                InfoPlayButton.Visibility = Visibility.Visible;
                 InfoTitle.Text = prog.Title;
                 var localStart = prog.StartUtc.ToLocalTime().DateTime;
                 var localEnd = prog.EndUtc.ToLocalTime().DateTime;


### PR DESCRIPTION
## Summary
- Keep EPG info panel visible with a placeholder when no programme is selected
- Toggle info details and play button visibility based on segment selection

## Testing
- `dotnet build` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*


------
https://chatgpt.com/codex/tasks/task_b_68af2e635b90832ea57304a389119727