### PR TITLE
Fix timeline header scroll sync and click recenter bug

### DIFF
--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -97,9 +97,11 @@
         </Grid>
 
         <!-- Main guide area: list of channels and their programmes -->
-        <ScrollViewer HorizontalScrollBarVisibility="Auto"
+        <ScrollViewer x:Name="GuideScroll"
+                      HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto"
-                      Margin="8">
+                      Margin="8"
+                      ScrollChanged="GuideScroll_ScrollChanged">
             <ItemsControl x:Name="TimelineList"
                           VirtualizingStackPanel.IsVirtualizing="True"
                           VirtualizingStackPanel.VirtualizationMode="Recycling">
@@ -132,7 +134,8 @@
                                                        Height="40"
                                                        Margin="1,0"
                                                        Background="{Binding Background}"
-                                                       MouseLeftButtonDown="Segment_MouseLeftButtonDown">
+                                                       MouseLeftButtonDown="Segment_MouseLeftButtonDown"
+                                                       RequestBringIntoView="Segment_RequestBringIntoView">
                                                     <TextBlock Text="{Binding Title}" VerticalAlignment="Center" Padding="2" TextTrimming="CharacterEllipsis" Foreground="{DynamicResource TextBrush}"/>
                                                 </Border>
                                             </DataTemplate>

--- a/Views/EpgGuideWindow.xaml.cs
+++ b/Views/EpgGuideWindow.xaml.cs
@@ -396,6 +396,19 @@ namespace WaxIPTV.Views
             }
         }
 
+        private void GuideScroll_ScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            if (e.HorizontalChange != 0)
+            {
+                TimelineHeaderScroll.ScrollToHorizontalOffset(e.HorizontalOffset);
+            }
+        }
+
+        private void Segment_RequestBringIntoView(object sender, RequestBringIntoViewEventArgs e)
+        {
+            e.Handled = true;
+        }
+
         /// <summary>
         /// Handles mouse left button down on programme segments.  If the user
         /// double‑clicks, the associated channel starts playing immediately via


### PR DESCRIPTION
## Summary
- Sync the timeline header with the guide's horizontal scroll viewer
- Prevent program blocks from forcing horizontal recentering when clicked

## Testing
- `dotnet build` *(fails: Could not resolve SDK Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_b_68af305fc05c832e8a8bd248a3f852d6