### PR TITLE
style: add themed combobox

### DIFF
--- a/Theming/ThemeResources.xaml
+++ b/Theming/ThemeResources.xaml
@@ -123,4 +123,99 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!-- Custom ComboBox style enabling full theming support -->
+    <ControlTemplate x:Key="ComboBoxToggleButton" TargetType="{x:Type ToggleButton}">
+        <Border x:Name="Border"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                CornerRadius="{DynamicResource ThemeCornerRadius}">
+            <Path x:Name="Arrow" Data="M 0 0 L 4 4 L 8 0 Z"
+                  Fill="{DynamicResource TextBrush}"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"/>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource AccentHoverBrush}"/>
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter TargetName="Border" Property="Background" Value="{DynamicResource AccentSelectionBrush}"/>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style TargetType="{x:Type ComboBox}">
+        <Setter Property="Background" Value="{DynamicResource DropdownBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource DividerBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Padding" Value="{DynamicResource SpacingS}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ComboBox}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition Width="20"/>
+                        </Grid.ColumnDefinitions>
+                        <Border x:Name="Bd"
+                                Grid.ColumnSpan="2"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{DynamicResource ThemeCornerRadius}"/>
+                        <ContentPresenter Margin="4,0,4,0"
+                                          VerticalAlignment="Center"
+                                          HorizontalAlignment="Left"
+                                          Content="{TemplateBinding SelectionBoxItem}"
+                                          ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"/>
+                        <ToggleButton x:Name="ToggleButton"
+                                      Grid.Column="1"
+                                      Template="{StaticResource ComboBoxToggleButton}"
+                                      Background="{TemplateBinding Background}"
+                                      BorderBrush="{TemplateBinding BorderBrush}"
+                                      Focusable="False"
+                                      IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                      ClickMode="Press"/>
+                        <Popup x:Name="Popup"
+                               Placement="Bottom"
+                               PlacementTarget="{Binding ElementName=ToggleButton}"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               PopupAnimation="Slide">
+                            <Grid x:Name="DropDown"
+                                  SnapsToDevicePixels="True"
+                                  MinWidth="{TemplateBinding ActualWidth}"
+                                  MaxHeight="{TemplateBinding MaxDropDownHeight}">
+                                <Border x:Name="DropDownBorder"
+                                        Background="{DynamicResource DropdownBrush}"
+                                        BorderBrush="{DynamicResource DividerBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="{DynamicResource ThemeCornerRadius}"/>
+                                <ScrollViewer Margin="4"
+                                              SnapsToDevicePixels="True">
+                                    <StackPanel IsItemsHost="True"
+                                                KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                </ScrollViewer>
+                            </Grid>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="HasItems" Value="False">
+                            <Setter TargetName="DropDownBorder" Property="MinHeight" Value="16"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/Views/EpgGuideWindow.xaml
+++ b/Views/EpgGuideWindow.xaml
@@ -36,11 +36,7 @@
                       Width="150"
                       Margin="0,0,8,0"
                       VerticalAlignment="Center"
-                      SelectionChanged="GroupFilter_SelectionChanged"
-                      Background="{DynamicResource DropdownBrush}"
-                      Foreground="{DynamicResource TextBrush}"
-                      BorderBrush="{DynamicResource DividerBrush}"
-                      BorderThickness="1"/>
+                      SelectionChanged="GroupFilter_SelectionChanged"/>
             <Button Content="Close"
                     Width="80"
                     Margin="0"

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -92,11 +92,7 @@
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" Margin="0,0,8,0">
                         <TextBlock Text="Group" VerticalAlignment="Center" Margin="0,0,6,0"/>
                         <ComboBox x:Name="GroupFilter" Width="160"
-                                  SelectionChanged="GroupFilter_SelectionChanged"
-                                  Background="{DynamicResource DropdownBrush}"
-                                  Foreground="{DynamicResource TextBrush}"
-                                  BorderBrush="{DynamicResource DividerBrush}"
-                                  BorderThickness="1"/>
+                                  SelectionChanged="GroupFilter_SelectionChanged"/>
                     </StackPanel>
                     <!-- EPG counters: displays how many channels and programmes were loaded and mapped.
                          Placed on the right side of the filter bar.  Hidden until EPG is loaded. -->

--- a/Views/SettingsWindow.xaml
+++ b/Views/SettingsWindow.xaml
@@ -83,7 +83,6 @@
                                VerticalAlignment="Center"/>
                     <ComboBox Grid.Row="0" Grid.Column="1"
                               Margin="0,0,8,8"
-                              Background="{DynamicResource DropdownBrush}"
                               ItemsSource="{Binding PlayerOptions}"
                               SelectedItem="{Binding Player, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
@@ -309,7 +308,6 @@
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="Font" Width="110" VerticalAlignment="Center"/>
                                     <ComboBox Width="220"
-                                              Background="{DynamicResource DropdownBrush}"
                                               ItemsSource="{Binding SystemFonts}"
                                               SelectedItem="{Binding SelectedFontFamily}"
                                               DisplayMemberPath="Source"/>


### PR DESCRIPTION
## Summary
- add global ComboBox style with theme-aware colors and template
- remove inline ComboBox styling from Main, EPG guide and settings to use theme defaults

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_b_68af38cda110832ea1cb1bfcd46f7194